### PR TITLE
Fixed newline bug when reading input_spectrum.txt, and fan beam bug

### DIFF
--- a/src/PrimaryGeneratorAction.cc
+++ b/src/PrimaryGeneratorAction.cc
@@ -195,6 +195,7 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
   if(fan_beam){ //let's do a fan beam
 	  theta = acos(0.5*(G4UniformRand()-0.5))-90.*CLHEP::deg;
 	  phi   = 0.005*(G4UniformRand()-0.5);
+    vDir = G4ThreeVector(sin(theta)*cos(phi),sin(theta)*sin(phi),cos(theta));
   }
   else if(isotropic_beam || isotropic_extended){ //isotropic
     theta = acos(2*G4UniformRand()-1); //truly isotropic
@@ -227,9 +228,8 @@ void PrimaryGeneratorAction::ReadInputSpectrumFile(std::string filename){
   std::ifstream f(filename);
   if(f.is_open()) { //check that the file is open
     std::cout<<"oooooooooooooo Reading input file for beam energies oooooooooooo"<<std::endl;
-    while(!f.eof()) {
-      float a,b;
-      f>>a>>b;
+    float a,b;
+    while(f >> a >> b) {
       e.push_back(a);
       dNde.push_back(b);
     }


### PR DESCRIPTION
If input_spectrum.txt contains a newline (most commonly seen at the very end of the file), the current code

```
    while(!f.eof()) {
      float a,b;
      f>>a>>b;
      e.push_back(a);
      dNde.push_back(b);
    }
```

will read the newline and append the (a, b) of the previous line to e and dNde. This will create incorrect sampling weights when using discrete energy sampling since a given energy will essentially be given twice the weight.

![Screen Shot 2021-07-01 at 12 28 18 PM](https://user-images.githubusercontent.com/19719622/124161189-1beffa80-da6b-11eb-9619-34f0b9aa6b51.png)

A simple fix is to just ignore empty lines as follows:

```
    float a,b;
    while(f >> a >> b) {
      e.push_back(a);
      dNde.push_back(b);
    }
```

Producing the correct weights:

![Screen Shot 2021-07-01 at 12 28 05 PM](https://user-images.githubusercontent.com/19719622/124161298-3de97d00-da6b-11eb-905e-94a8b55191d1.png)

Furthermore, there was a bug from a previous commit which removed the line

`vDir = G4ThreeVector(sin(theta)*cos(phi),sin(theta)*sin(phi),cos(theta));`

when using a fan beam.

