### PR TITLE
Updating grasshopper.cc by commenting out G4VIS_USE

### DIFF
--- a/grasshopper.cc
+++ b/grasshopper.cc
@@ -69,12 +69,12 @@ G4String RootOutputFile;
 
 G4GDMLParser parser;
 
-#define G4VIS_USE
+//#define G4VIS_USE
 
-#ifdef G4VIS_USE
+//#ifdef G4VIS_USE
 #include "VisManager.hh"
 #include "G4TrajectoryDrawByParticleID.hh"
-#endif
+//#endif
 
 
 //#include "AnalysisManager.hh"


### PR DESCRIPTION
G4VIS_USE is commented out to prevent the VisManager reference error that occurs when trying to make grasshopper after cmake.